### PR TITLE
fix urls

### DIFF
--- a/gerbers/readme.md
+++ b/gerbers/readme.md
@@ -32,21 +32,21 @@ R0.4.5 - 2 layers, use microRusEfi-bom.csv and microRusEfi-cpl.csv files for top
 
 Pre-assembled by jlcpcb
 
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_pre_assembled_front.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_pre_assembled_front.jpg)
 
 More-assembled, based on pre-assembled by jlcpcb. 
 
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_more_assembled_front.jpg)
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_more_assembled_back.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_more_assembled_front.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0.4.5_more_assembled_back.jpg)
 
 ##R0.3 Hall Mode Mazda Miata 2003
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0_3_assembled_front_hall_setup.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0_3_assembled_front_hall_setup.jpg)
 
 
 # R0.1
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0_1_pcb.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0_1_pcb.jpg)
 
 ##R0.1 Hall Mode
-![img](https://raw.githubusercontent.com/wiki/rusefi/rusefi_documentation/Hardware/microRusEFI/Hardware_microRusEFI_0_1_assembled_front_hall_setup.jpg)
+![img](https://raw.githubusercontent.com/rusefi/rusefi_documentation/master/Hardware/microRusEFI/Hardware_microRusEFI_0_1_assembled_front_hall_setup.jpg)
 
 


### PR DESCRIPTION
I don't know how these URLs got broken. Maybe Github changed how the URLs work at some point, and the images were in a branch called "wiki"?
This should fix https://github.com/rusefi/rusefi_documentation/issues/343